### PR TITLE
Add backfill logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release Notes for Best Sellers
 
+## Unreleased
+
+### Added
+- Backfill logs table for tracking order processing failures during backfill and daily stats jobs
+- Backfill logs displayed on the Operations page with clear button
+- Dashboard empty state notice with link to backfill utility when no data exists
+- Console commands for clearing and refreshing individual data tables: `clear-orders`, `clear-daily-stats`, `clear-logs`, `refresh-orders`, `refresh-daily-stats`
+- Console `--start-date`/`--end-date` options for scoping backfill to a date range
+- Console `--date` option for rebuilding daily stats for a single day
+- Auto-pruning of backfill logs via Craft garbage collection (keeps 500 most recent)
+
+### Changed
+- Backfill utility UI now explains that empty date fields will process all orders
+- All backfill utility strings are translatable
+- Backfill and daily stats jobs now catch errors per-item and continue processing instead of failing the entire batch
+
 ## 1.1.0 - 2026-03-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes for Best Sellers
 
-## Unreleased
+## 1.1.1
 
 ### Added
 - Backfill logs table for tracking order processing failures during backfill and daily stats jobs

--- a/README.md
+++ b/README.md
@@ -204,7 +204,11 @@ For additional examples, see the [Developer Documentation](docs/usage.md).
 | Command | Description |
 |---------|-------------|
 | `./craft best-sellers/backfill` | Queue existing completed orders for processing (batches of 25) |
+| `./craft best-sellers/backfill --start-date=2025-01-01 --end-date=2025-12-31` | Backfill orders within a specific date range |
+| `./craft best-sellers/backfill --fresh` | Clear all recorded data and reprocess from scratch |
 | `./craft best-sellers/backfill/daily-stats` | Rebuild the daily stats table from order data |
+| `./craft best-sellers/backfill/daily-stats --date=2026-03-15` | Rebuild daily stats for a single date |
+| `./craft best-sellers/backfill/daily-stats --fresh` | Truncate the daily stats table and rebuild |
 
 Both commands are also available from the **Utilities > Best Sellers** page in the control panel.
 

--- a/README.md
+++ b/README.md
@@ -205,10 +205,13 @@ For additional examples, see the [Developer Documentation](docs/usage.md).
 |---------|-------------|
 | `./craft best-sellers/backfill` | Queue existing completed orders for processing (batches of 25) |
 | `./craft best-sellers/backfill --start-date=2025-01-01 --end-date=2025-12-31` | Backfill orders within a specific date range |
-| `./craft best-sellers/backfill --fresh` | Clear all recorded data and reprocess from scratch |
 | `./craft best-sellers/backfill/daily-stats` | Rebuild the daily stats table from order data |
 | `./craft best-sellers/backfill/daily-stats --date=2026-03-15` | Rebuild daily stats for a single date |
-| `./craft best-sellers/backfill/daily-stats --fresh` | Truncate the daily stats table and rebuild |
+| `./craft best-sellers/backfill/refresh-orders` | Clear variant sales and reprocess all orders |
+| `./craft best-sellers/backfill/refresh-daily-stats` | Clear daily stats and rebuild from order data |
+| `./craft best-sellers/backfill/clear-orders` | Clear the variant sales table |
+| `./craft best-sellers/backfill/clear-daily-stats` | Clear the daily stats table |
+| `./craft best-sellers/backfill/clear-logs` | Clear all backfill log entries |
 
 Both commands are also available from the **Utilities > Best Sellers** page in the control panel.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "fostercommerce/commerce-best-sellers",
   "type": "craft-plugin",
   "license": "proprietary",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "support": {
     "email": "support@fostercommerce.com",
     "issues": "https://github.com/fostercommerce/commerce-best-sellers/issues?state=open",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -168,6 +168,19 @@ Process existing completed orders that were placed before the plugin was install
 ./craft best-sellers/backfill
 ```
 
+To limit to a specific date range:
+
+```bash
+./craft best-sellers/backfill --start-date=2025-01-01 --end-date=2025-12-31
+```
+
+To clear existing data and reprocess from scratch, add `--fresh`. This can be combined with a date range to only clear and reprocess a specific period:
+
+```bash
+./craft best-sellers/backfill --fresh
+./craft best-sellers/backfill --fresh --start-date=2025-01-01 --end-date=2025-12-31
+```
+
 Orders are queued in batches of 25. Progress is visible in the Craft queue.
 
 ### Rebuild Daily Stats
@@ -179,6 +192,18 @@ Rebuild the pre-aggregated daily stats table from order data:
 ```
 
 This is useful after running the backfill, or if stats get out of sync. The command automatically detects the date range from your completed orders.
+
+To rebuild stats for a single date (e.g. if one day looks off):
+
+```bash
+./craft best-sellers/backfill/daily-stats --date=2026-03-15
+```
+
+To truncate the entire daily stats table and rebuild from scratch:
+
+```bash
+./craft best-sellers/backfill/daily-stats --fresh
+```
 
 Both commands are also available from the **Utilities > Best Sellers** page in the control panel, where you can optionally specify a date range for the backfill.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -174,14 +174,14 @@ To limit to a specific date range:
 ./craft best-sellers/backfill --start-date=2025-01-01 --end-date=2025-12-31
 ```
 
-To clear existing data and reprocess from scratch, add `--fresh`. This can be combined with a date range to only clear and reprocess a specific period:
+Orders are queued in batches of 25. Progress is visible in the Craft queue.
+
+To clear existing variant sales and reprocess from scratch:
 
 ```bash
-./craft best-sellers/backfill --fresh
-./craft best-sellers/backfill --fresh --start-date=2025-01-01 --end-date=2025-12-31
+./craft best-sellers/backfill/refresh-orders
+./craft best-sellers/backfill/refresh-orders --start-date=2025-01-01 --end-date=2025-12-31
 ```
-
-Orders are queued in batches of 25. Progress is visible in the Craft queue.
 
 ### Rebuild Daily Stats
 
@@ -199,13 +199,24 @@ To rebuild stats for a single date (e.g. if one day looks off):
 ./craft best-sellers/backfill/daily-stats --date=2026-03-15
 ```
 
-To truncate the entire daily stats table and rebuild from scratch:
+To clear and rebuild the entire daily stats table:
 
 ```bash
-./craft best-sellers/backfill/daily-stats --fresh
+./craft best-sellers/backfill/refresh-daily-stats
+./craft best-sellers/backfill/refresh-daily-stats --date=2026-03-15
 ```
 
-Both commands are also available from the **Utilities > Best Sellers** page in the control panel, where you can optionally specify a date range for the backfill.
+### Clearing Data
+
+Clear individual tables without reprocessing:
+
+```bash
+./craft best-sellers/backfill/clear-orders
+./craft best-sellers/backfill/clear-daily-stats
+./craft best-sellers/backfill/clear-logs
+```
+
+All commands are also available from the **Utilities > Best Sellers** page in the control panel, where you can optionally specify a date range for the backfill.
 
 ## Events
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,6 +16,7 @@ use craft\events\DefineBehaviorsEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterUrlRulesEvent;
 use craft\events\RegisterUserPermissionsEvent;
+use craft\services\Gc;
 use craft\services\UserPermissions;
 use craft\services\Utilities;
 use craft\web\twig\variables\CraftVariable;
@@ -24,6 +25,7 @@ use fostercommerce\bestsellers\behaviors\SaleQueryBehavior;
 use fostercommerce\bestsellers\behaviors\SalesBehavior;
 use fostercommerce\bestsellers\helpers\Query;
 use fostercommerce\bestsellers\models\Settings;
+use fostercommerce\bestsellers\services\BackfillLogs;
 use fostercommerce\bestsellers\services\CartAbandonment;
 use fostercommerce\bestsellers\services\CustomerStats;
 use fostercommerce\bestsellers\services\DailyStats;
@@ -49,6 +51,7 @@ use yii\base\Event;
  * @property-read OperationsStats $operationsStats
  * @property-read CartAbandonment $cartAbandonment
  * @property-read SummaryEngine $summaryEngine
+ * @property-read BackfillLogs $backfillLogs
  */
 class Plugin extends BasePlugin
 {
@@ -56,7 +59,7 @@ class Plugin extends BasePlugin
 
 	public const PERMISSION_BACKFILL = 'best-sellers:backfill';
 
-	public string $schemaVersion = '1.2.0';
+	public string $schemaVersion = '1.3.0';
 
 	public bool $hasCpSettings = false;
 
@@ -77,6 +80,7 @@ class Plugin extends BasePlugin
 				'operationsStats' => OperationsStats::class,
 				'cartAbandonment' => CartAbandonment::class,
 				'summaryEngine' => SummaryEngine::class,
+				'backfillLogs' => BackfillLogs::class,
 			],
 		];
 	}
@@ -121,6 +125,14 @@ class Plugin extends BasePlugin
 						],
 					],
 				];
+			}
+		);
+
+		Event::on(
+			Gc::class,
+			Gc::EVENT_RUN,
+			function (): void {
+				$this->backfillLogs->prune();
 			}
 		);
 	}
@@ -208,6 +220,12 @@ class Plugin extends BasePlugin
 	{
 		/** @var SummaryEngine */
 		return $this->get('summaryEngine');
+	}
+
+	public function getBackfillLogs(): BackfillLogs
+	{
+		/** @var BackfillLogs */
+		return $this->get('backfillLogs');
 	}
 
 	protected function createSettingsModel(): ?Model
@@ -316,6 +334,7 @@ class Plugin extends BasePlugin
 				$registerUrlRulesEvent->rules['best-sellers/customers/customers-data'] = 'best-sellers/customers/customers-data';
 				$registerUrlRulesEvent->rules['best-sellers/customers/export-csv'] = 'best-sellers/customers/export-csv';
 				$registerUrlRulesEvent->rules['best-sellers/operations'] = 'best-sellers/operations';
+				$registerUrlRulesEvent->rules['best-sellers/operations/clear-logs'] = 'best-sellers/operations/clear-logs';
 
 				// Backward compatibility redirects
 				$registerUrlRulesEvent->rules['best-sellers/reports'] = 'best-sellers/orders';

--- a/src/assetbundles/dist/css/reports.css
+++ b/src/assetbundles/dist/css/reports.css
@@ -529,6 +529,26 @@
 	margin: 0;
 }
 
+/* Empty state */
+.bs-empty-state {
+	background: #fef9e7;
+	border: 1px solid #f0e0a0;
+	border-radius: 8px;
+	padding: 1.5rem;
+	margin-bottom: 2rem;
+	text-align: center;
+}
+
+.bs-empty-state p {
+	margin: 0 0 1rem;
+	font-size: 0.95rem;
+	color: #6c757d;
+}
+
+.bs-empty-state .btn {
+	margin: 0;
+}
+
 /* Loading animation */
 .bs-loading {
 	display: flex;

--- a/src/console/controllers/BackfillController.php
+++ b/src/console/controllers/BackfillController.php
@@ -27,20 +27,16 @@ class BackfillController extends Controller
 
 	public ?string $date = null;
 
-	public bool $fresh = false;
-
 	public function options($actionID): array
 	{
 		$options = parent::options($actionID);
-		if ($actionID === 'index') {
+		if ($actionID === 'index' || $actionID === 'refresh-orders') {
 			$options[] = 'startDate';
 			$options[] = 'endDate';
-			$options[] = 'fresh';
 		}
 
-		if ($actionID === 'daily-stats') {
+		if ($actionID === 'daily-stats' || $actionID === 'refresh-daily-stats') {
 			$options[] = 'date';
-			$options[] = 'fresh';
 		}
 
 		return $options;
@@ -51,31 +47,137 @@ class BackfillController extends Controller
 	 *
 	 * Run with: ./craft best-sellers/backfill
 	 *           ./craft best-sellers/backfill --start-date=2025-01-01 --end-date=2025-12-31
-	 *           ./craft best-sellers/backfill --fresh
 	 */
 	public function actionIndex(int $batchSize = 25): int
 	{
-		if ($this->fresh) {
-			$deleteQuery = Craft::$app->db->createCommand();
-			if ($this->startDate && $this->endDate) {
-				$deleteQuery->delete(Table::VARIANT_SALES, [
-					'between', 'dateOrdered', $this->startDate, $this->endDate . ' 23:59:59',
-				]);
-				$this->stdout("Cleared variant sales for {$this->startDate} to {$this->endDate}.\n");
-			} else {
-				$deleteQuery->truncateTable(Table::VARIANT_SALES);
-				$this->stdout("Cleared all variant sales.\n");
-			}
+		return $this->_queueOrders($batchSize);
+	}
 
-			$deleteQuery->execute();
+	/**
+	 * Clear and reprocess the variant sales table.
+	 *
+	 * Run with: ./craft best-sellers/backfill/refresh-orders
+	 *           ./craft best-sellers/backfill/refresh-orders --start-date=2025-01-01 --end-date=2025-12-31
+	 */
+	public function actionRefreshOrders(int $batchSize = 25): int
+	{
+		$deleteQuery = Craft::$app->db->createCommand();
+		if ($this->startDate && $this->endDate) {
+			$deleteQuery->delete(Table::VARIANT_SALES, [
+				'between', 'dateOrdered', $this->startDate, $this->endDate . ' 23:59:59',
+			]);
+			$this->stdout("Cleared variant sales for {$this->startDate} to {$this->endDate}.\n");
+		} else {
+			$deleteQuery->truncateTable(Table::VARIANT_SALES);
+			$this->stdout("Cleared all variant sales.\n");
 		}
 
-		// Get IDs of processed orders.
+		$deleteQuery->execute();
+
+		return $this->_queueOrders($batchSize);
+	}
+
+	/**
+	 * Rebuild daily stats table from commerce_orders.
+	 *
+	 * Pass --date=YYYY-MM-DD to rebuild a single day.
+	 *
+	 * Run with: ./craft best-sellers/backfill/daily-stats
+	 *           ./craft best-sellers/backfill/daily-stats --date=2026-03-15
+	 */
+	public function actionDailyStats(): int
+	{
+		if ($this->date !== null) {
+			$plugin = Plugin::getInstance();
+			$plugin->dailyStats->aggregateDay($this->date);
+			$this->stdout("Daily stats rebuilt for {$this->date}.\n");
+			return ExitCode::OK;
+		}
+
+		return $this->_rebuildDailyStats();
+	}
+
+	/**
+	 * Clear and rebuild the daily stats table.
+	 *
+	 * Pass --date=YYYY-MM-DD to clear and rebuild a single day.
+	 *
+	 * Run with: ./craft best-sellers/backfill/refresh-daily-stats
+	 *           ./craft best-sellers/backfill/refresh-daily-stats --date=2026-03-15
+	 */
+	public function actionRefreshDailyStats(): int
+	{
+		if ($this->date !== null) {
+			Craft::$app->db->createCommand()
+				->delete(Table::DAILY_STATS, [
+					'date' => $this->date,
+				])
+				->execute();
+			$this->stdout("Cleared daily stats for {$this->date}.\n");
+
+			$plugin = Plugin::getInstance();
+			$plugin->dailyStats->aggregateDay($this->date);
+			$this->stdout("Daily stats rebuilt for {$this->date}.\n");
+			return ExitCode::OK;
+		}
+
+		Craft::$app->db->createCommand()
+			->truncateTable(Table::DAILY_STATS)
+			->execute();
+		$this->stdout("Cleared all daily stats.\n");
+
+		return $this->_rebuildDailyStats();
+	}
+
+	/**
+	 * Clear the variant sales table.
+	 *
+	 * Run with: ./craft best-sellers/backfill/clear-orders
+	 */
+	public function actionClearOrders(): int
+	{
+		Craft::$app->db->createCommand()
+			->truncateTable(Table::VARIANT_SALES)
+			->execute();
+		$this->stdout("Cleared all variant sales.\n");
+
+		return ExitCode::OK;
+	}
+
+	/**
+	 * Clear the daily stats table.
+	 *
+	 * Run with: ./craft best-sellers/backfill/clear-daily-stats
+	 */
+	public function actionClearDailyStats(): int
+	{
+		Craft::$app->db->createCommand()
+			->truncateTable(Table::DAILY_STATS)
+			->execute();
+		$this->stdout("Cleared all daily stats.\n");
+
+		return ExitCode::OK;
+	}
+
+	/**
+	 * Clear all backfill log entries.
+	 *
+	 * Run with: ./craft best-sellers/backfill/clear-logs
+	 */
+	public function actionClearLogs(): int
+	{
+		$count = Plugin::getInstance()->backfillLogs->deleteAll();
+		$this->stdout("Cleared {$count} log entries.\n");
+
+		return ExitCode::OK;
+	}
+
+	private function _queueOrders(int $batchSize): int
+	{
 		$processedOrderIds = VariantSale::find()
 			->select('orderId')
 			->column();
 
-		// Count orders that are completed and not yet processed.
 		$query = Order::find()
 			->isCompleted(true)
 			->andWhere(['not in', 'id', $processedOrderIds]);
@@ -100,33 +202,8 @@ class BackfillController extends Controller
 		return ExitCode::OK;
 	}
 
-	/**
-	 * Rebuild daily stats table from commerce_orders.
-	 *
-	 * Pass --date=YYYY-MM-DD to rebuild a single day.
-	 * Pass --fresh to truncate the table before rebuilding.
-	 * Without --date, rebuilds the entire range.
-	 *
-	 * Run with: ./craft best-sellers/backfill/daily-stats
-	 *           ./craft best-sellers/backfill/daily-stats --date=2026-03-15
-	 *           ./craft best-sellers/backfill/daily-stats --fresh
-	 */
-	public function actionDailyStats(): int
+	private function _rebuildDailyStats(): int
 	{
-		if ($this->date !== null) {
-			$plugin = Plugin::getInstance();
-			$plugin->dailyStats->aggregateDay($this->date);
-			$this->stdout("Daily stats rebuilt for {$this->date}.\n");
-			return ExitCode::OK;
-		}
-
-		if ($this->fresh) {
-			Craft::$app->db->createCommand()
-				->truncateTable(Table::DAILY_STATS)
-				->execute();
-			$this->stdout("Cleared all daily stats.\n");
-		}
-
 		/** @var array{minDate: ?string, maxDate: ?string}|false $row */
 		$row = (new Query())
 			->select([
@@ -151,20 +228,6 @@ class BackfillController extends Controller
 		]));
 
 		$this->stdout("Daily stats rebuild queued for {$startDate} to {$endDate}.\n");
-		return ExitCode::OK;
-	}
-
-	/**
-	 * Clear all backfill log entries.
-	 *
-	 * Run with: ./craft best-sellers/backfill/clear-logs
-	 */
-	public function actionClearLogs(): int
-	{
-		$plugin = Plugin::getInstance();
-		$count = $plugin->backfillLogs->deleteAll();
-		$this->stdout("Cleared {$count} log entries.\n");
-
 		return ExitCode::OK;
 	}
 }

--- a/src/console/controllers/BackfillController.php
+++ b/src/console/controllers/BackfillController.php
@@ -8,8 +8,10 @@ use craft\commerce\elements\Order;
 use craft\db\Query;
 use craft\helpers\Queue as QueueHelper;
 use DateTime;
+use fostercommerce\bestsellers\db\Table;
 use fostercommerce\bestsellers\jobs\BackfillOrdersJob;
 use fostercommerce\bestsellers\jobs\RebuildDailyStatsJob;
+use fostercommerce\bestsellers\Plugin;
 use fostercommerce\bestsellers\records\VariantSale;
 use yii\console\Controller;
 use yii\console\ExitCode;
@@ -19,28 +21,77 @@ use yii\console\ExitCode;
  */
 class BackfillController extends Controller
 {
+	public ?string $startDate = null;
+
+	public ?string $endDate = null;
+
+	public ?string $date = null;
+
+	public bool $fresh = false;
+
+	public function options($actionID): array
+	{
+		$options = parent::options($actionID);
+		if ($actionID === 'index') {
+			$options[] = 'startDate';
+			$options[] = 'endDate';
+			$options[] = 'fresh';
+		}
+
+		if ($actionID === 'daily-stats') {
+			$options[] = 'date';
+			$options[] = 'fresh';
+		}
+
+		return $options;
+	}
+
 	/**
 	 * Backfill previous orders in batches of 25.
 	 *
 	 * Run with: ./craft best-sellers/backfill
+	 *           ./craft best-sellers/backfill --start-date=2025-01-01 --end-date=2025-12-31
+	 *           ./craft best-sellers/backfill --fresh
 	 */
 	public function actionIndex(int $batchSize = 25): int
 	{
+		if ($this->fresh) {
+			$deleteQuery = Craft::$app->db->createCommand();
+			if ($this->startDate && $this->endDate) {
+				$deleteQuery->delete(Table::VARIANT_SALES, [
+					'between', 'dateOrdered', $this->startDate, $this->endDate . ' 23:59:59',
+				]);
+				$this->stdout("Cleared variant sales for {$this->startDate} to {$this->endDate}.\n");
+			} else {
+				$deleteQuery->truncateTable(Table::VARIANT_SALES);
+				$this->stdout("Cleared all variant sales.\n");
+			}
+
+			$deleteQuery->execute();
+		}
+
 		// Get IDs of processed orders.
 		$processedOrderIds = VariantSale::find()
 			->select('orderId')
 			->column();
 
 		// Count orders that are completed and not yet processed.
-		$totalOrders = Order::find()
+		$query = Order::find()
 			->isCompleted(true)
-			->andWhere(['not in', 'id', $processedOrderIds])
-			->count();
+			->andWhere(['not in', 'id', $processedOrderIds]);
+
+		if ($this->startDate && $this->endDate) {
+			$query->andWhere(['between', 'dateOrdered', $this->startDate, $this->endDate]);
+		}
+
+		$totalOrders = $query->count();
 
 		for ($offset = 0; $offset < $totalOrders; $offset += $batchSize) {
 			Craft::$app->queue->push(new BackfillOrdersJob([
 				'offset' => $offset,
 				'limit' => $batchSize,
+				'startDate' => $this->startDate,
+				'endDate' => $this->endDate,
 			]));
 			$this->stdout("Queued orders offset {$offset} to " . ($offset + $batchSize - 1) . "\n");
 		}
@@ -52,10 +103,30 @@ class BackfillController extends Controller
 	/**
 	 * Rebuild daily stats table from commerce_orders.
 	 *
+	 * Pass --date=YYYY-MM-DD to rebuild a single day.
+	 * Pass --fresh to truncate the table before rebuilding.
+	 * Without --date, rebuilds the entire range.
+	 *
 	 * Run with: ./craft best-sellers/backfill/daily-stats
+	 *           ./craft best-sellers/backfill/daily-stats --date=2026-03-15
+	 *           ./craft best-sellers/backfill/daily-stats --fresh
 	 */
 	public function actionDailyStats(): int
 	{
+		if ($this->date !== null) {
+			$plugin = Plugin::getInstance();
+			$plugin->dailyStats->aggregateDay($this->date);
+			$this->stdout("Daily stats rebuilt for {$this->date}.\n");
+			return ExitCode::OK;
+		}
+
+		if ($this->fresh) {
+			Craft::$app->db->createCommand()
+				->truncateTable(Table::DAILY_STATS)
+				->execute();
+			$this->stdout("Cleared all daily stats.\n");
+		}
+
 		/** @var array{minDate: ?string, maxDate: ?string}|false $row */
 		$row = (new Query())
 			->select([
@@ -80,6 +151,20 @@ class BackfillController extends Controller
 		]));
 
 		$this->stdout("Daily stats rebuild queued for {$startDate} to {$endDate}.\n");
+		return ExitCode::OK;
+	}
+
+	/**
+	 * Clear all backfill log entries.
+	 *
+	 * Run with: ./craft best-sellers/backfill/clear-logs
+	 */
+	public function actionClearLogs(): int
+	{
+		$plugin = Plugin::getInstance();
+		$count = $plugin->backfillLogs->deleteAll();
+		$this->stdout("Cleared {$count} log entries.\n");
+
 		return ExitCode::OK;
 	}
 }

--- a/src/controllers/BackfillController.php
+++ b/src/controllers/BackfillController.php
@@ -6,11 +6,13 @@ use Craft;
 use craft\commerce\db\Table as CommerceTable;
 use craft\commerce\elements\Order;
 use craft\db\Query;
+use craft\helpers\DateTimeHelper;
 use craft\helpers\Queue as QueueHelper;
 use craft\web\Controller;
 use craft\web\Request;
 use DateTime;
 use Exception;
+use fostercommerce\bestsellers\db\Table;
 use fostercommerce\bestsellers\jobs\BackfillOrdersJob;
 use fostercommerce\bestsellers\jobs\RebuildDailyStatsJob;
 use fostercommerce\bestsellers\Plugin;
@@ -55,9 +57,15 @@ class BackfillController extends Controller
 		/** @var Request $request */
 		$request = Craft::$app->getRequest();
 
-		// Get date range from form POST data.
-		$startDate = $request->getBodyParam('startDate'); // YYYY-MM-DD
-		$endDate = $request->getBodyParam('endDate');   // YYYY-MM-DD
+		// Craft date fields post arrays; convert to Y-m-d strings.
+		/** @var array<string, string>|string|null $rawStart */
+		$rawStart = $request->getBodyParam('startDate');
+		/** @var array<string, string>|string|null $rawEnd */
+		$rawEnd = $request->getBodyParam('endDate');
+		$startDateTime = DateTimeHelper::toDateTime($rawStart);
+		$endDateTime = DateTimeHelper::toDateTime($rawEnd);
+		$startDate = $startDateTime ? $startDateTime->format('Y-m-d') : null;
+		$endDate = $endDateTime ? $endDateTime->format('Y-m-d') : null;
 
 		// Get processed order IDs.
 		$processedOrderIds = VariantSale::find()
@@ -129,5 +137,69 @@ class BackfillController extends Controller
 
 		Craft::$app->session->setNotice(Craft::t('best-sellers', 'Daily stats rebuild queued.'));
 		return $this->redirectToPostedUrl();
+	}
+
+	/**
+	 * @throws MethodNotAllowedHttpException
+	 * @throws BadRequestHttpException
+	 */
+	public function actionClearOrders(): Response
+	{
+		$this->requirePostRequest();
+
+		Craft::$app->db->createCommand()
+			->truncateTable(Table::VARIANT_SALES)
+			->execute();
+
+		Craft::$app->session->setNotice(Craft::t('best-sellers', 'Variant sales cleared.'));
+		return $this->redirectToPostedUrl();
+	}
+
+	/**
+	 * @throws MethodNotAllowedHttpException
+	 * @throws BadRequestHttpException
+	 */
+	public function actionClearDailyStats(): Response
+	{
+		$this->requirePostRequest();
+
+		Craft::$app->db->createCommand()
+			->truncateTable(Table::DAILY_STATS)
+			->execute();
+
+		Craft::$app->session->setNotice(Craft::t('best-sellers', 'Daily stats cleared.'));
+		return $this->redirectToPostedUrl();
+	}
+
+	/**
+	 * @throws MethodNotAllowedHttpException
+	 * @throws BadRequestHttpException
+	 * @throws Exception
+	 */
+	public function actionRefreshOrders(): Response
+	{
+		$this->requirePostRequest();
+
+		Craft::$app->db->createCommand()
+			->truncateTable(Table::VARIANT_SALES)
+			->execute();
+
+		return $this->actionIndex();
+	}
+
+	/**
+	 * @throws MethodNotAllowedHttpException
+	 * @throws BadRequestHttpException
+	 * @throws Exception
+	 */
+	public function actionRefreshDailyStats(): Response
+	{
+		$this->requirePostRequest();
+
+		Craft::$app->db->createCommand()
+			->truncateTable(Table::DAILY_STATS)
+			->execute();
+
+		return $this->actionRebuildDailyStats();
 	}
 }

--- a/src/controllers/OperationsController.php
+++ b/src/controllers/OperationsController.php
@@ -7,6 +7,7 @@ use craft\commerce\db\Table as CommerceTable;
 use craft\commerce\Plugin as Commerce;
 use craft\db\Query;
 use fostercommerce\bestsellers\assetbundles\ReportsAsset;
+use fostercommerce\bestsellers\Plugin;
 use yii\web\Response;
 
 class OperationsController extends BaseReportController
@@ -59,6 +60,8 @@ class OperationsController extends BaseReportController
 			])
 			->all();
 
+		$backfillLogs = Plugin::getInstance()->backfillLogs->getAll();
+
 		return $this->renderTemplate('best-sellers/_operations', [
 			'title' => Craft::t('best-sellers', 'Operations'),
 			'selectedSubnavItem' => 'operations',
@@ -66,6 +69,16 @@ class OperationsController extends BaseReportController
 			'statusEmails' => $statusEmails,
 			'allEmails' => $allEmails,
 			'couponUsage' => $couponUsage,
+			'backfillLogs' => $backfillLogs,
 		]);
+	}
+
+	public function actionClearLogs(): Response
+	{
+		$this->requirePostRequest();
+		Plugin::getInstance()->backfillLogs->deleteAll();
+		Craft::$app->session->setNotice(Craft::t('best-sellers', 'Backfill logs cleared.'));
+
+		return $this->redirectToPostedUrl();
 	}
 }

--- a/src/controllers/OverviewController.php
+++ b/src/controllers/OverviewController.php
@@ -9,6 +9,7 @@ use craft\helpers\DateTimeHelper;
 use fostercommerce\bestsellers\assetbundles\ReportsAsset;
 use fostercommerce\bestsellers\helpers\KpiCards;
 use fostercommerce\bestsellers\Plugin;
+use fostercommerce\bestsellers\records\VariantSale;
 use yii\web\Response;
 
 class OverviewController extends BaseReportController
@@ -150,9 +151,12 @@ class OverviewController extends BaseReportController
 		$prevRawAov = array_column($prevDailyRows, 'averageOrderValue');
 		$prevDailyAov = array_map(floatval(...), $prevRawAov);
 
+		$hasData = VariantSale::find()->exists();
+
 		return $this->renderTemplate('best-sellers/_overview', [
 			'title' => Craft::t('best-sellers', 'Dashboard'),
 			'selectedSubnavItem' => 'overview',
+			'hasData' => $hasData,
 			'from' => $scope->from,
 			'to' => $scope->to,
 			'preset' => $scope->preset,

--- a/src/db/Table.php
+++ b/src/db/Table.php
@@ -7,4 +7,6 @@ abstract class Table
 	public const VARIANT_SALES = '{{%best_sellers_variant_sales}}';
 
 	public const DAILY_STATS = '{{%best_sellers_daily_stats}}';
+
+	public const BACKFILL_LOGS = '{{%best_sellers_backfill_logs}}';
 }

--- a/src/jobs/BackfillOrdersJob.php
+++ b/src/jobs/BackfillOrdersJob.php
@@ -8,6 +8,7 @@ use craft\queue\BaseJob;
 use DateTime;
 use fostercommerce\bestsellers\Plugin;
 use fostercommerce\bestsellers\records\VariantSale;
+use Throwable;
 
 class BackfillOrdersJob extends BaseJob
 {
@@ -46,7 +47,13 @@ class BackfillOrdersJob extends BaseJob
 		$plugin = Plugin::getInstance();
 
 		foreach ($orders as $i => $order) {
-			$plugin->sales->logOrderSales($order);
+			try {
+				$plugin->sales->logOrderSales($order);
+			} catch (Throwable $e) {
+				Craft::warning("Failed to process order #{$order->id}: {$e->getMessage()}", 'best-sellers');
+				$plugin->backfillLogs->log('backfill', (string) $order->id, $e->getMessage());
+			}
+
 			$this->setProgress($queue, ($i + 1) / $total);
 		}
 	}

--- a/src/jobs/RebuildDailyStatsJob.php
+++ b/src/jobs/RebuildDailyStatsJob.php
@@ -6,6 +6,7 @@ use Craft;
 use craft\base\Batchable;
 use craft\queue\BaseBatchedJob;
 use fostercommerce\bestsellers\Plugin;
+use Throwable;
 
 class RebuildDailyStatsJob extends BaseBatchedJob
 {
@@ -28,8 +29,14 @@ class RebuildDailyStatsJob extends BaseBatchedJob
 	{
 		/** @var string $date */
 		$date = $item;
-		$plugin = Plugin::getInstance();
-		$plugin->dailyStats->aggregateDay($date);
+
+		try {
+			$plugin = Plugin::getInstance();
+			$plugin->dailyStats->aggregateDay($date);
+		} catch (Throwable $throwable) {
+			Craft::warning("Failed to aggregate daily stats for {$date}: {$throwable->getMessage()}", 'best-sellers');
+			Plugin::getInstance()->backfillLogs->log('daily-stats', $date, $throwable->getMessage());
+		}
 	}
 
 	protected function defaultDescription(): ?string

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -3,6 +3,7 @@
 namespace fostercommerce\bestsellers\migrations;
 
 use craft\db\Migration;
+use fostercommerce\bestsellers\records\BackfillLog;
 use fostercommerce\bestsellers\records\DailyStat;
 use fostercommerce\bestsellers\records\VariantSale;
 
@@ -12,12 +13,14 @@ class Install extends Migration
 	{
 		$this->createVariantSalesTable();
 		$this->createDailyStatsTable();
+		$this->createBackfillLogsTable();
 
 		return true;
 	}
 
 	public function safeDown(): bool
 	{
+		$this->dropTableIfExists(BackfillLog::tableName());
 		$this->dropTableIfExists(DailyStat::tableName());
 		$this->dropTableIfExists(VariantSale::tableName());
 		return true;
@@ -78,5 +81,26 @@ class Install extends Migration
 		]);
 
 		$this->createIndex(null, DailyStat::tableName(), ['date'], true);
+	}
+
+	private function createBackfillLogsTable(): void
+	{
+		if ($this->db->tableExists(BackfillLog::tableName())) {
+			return;
+		}
+
+		$this->createTable(BackfillLog::tableName(), [
+			'id' => $this->primaryKey(),
+			'level' => $this->string()->notNull()->defaultValue('error'),
+			'type' => $this->string()->notNull(),
+			'reference' => $this->string()->notNull(),
+			'message' => $this->text()->null(),
+			'dateCreated' => $this->dateTime()->notNull(),
+			'dateUpdated' => $this->dateTime()->notNull(),
+			'uid' => $this->uid(),
+		]);
+
+		$this->createIndex(null, BackfillLog::tableName(), ['level']);
+		$this->createIndex(null, BackfillLog::tableName(), ['type']);
 	}
 }

--- a/src/migrations/m250327_180455_add_dateOrdered_column.php
+++ b/src/migrations/m250327_180455_add_dateOrdered_column.php
@@ -48,6 +48,6 @@ class m250327_180455_add_dateOrdered_column extends Migration
 			$this->dropColumn($table, 'dateOrdered');
 		}
 
-		return false;
+		return true;
 	}
 }

--- a/src/migrations/m260323_000001_create_backfill_logs_table.php
+++ b/src/migrations/m260323_000001_create_backfill_logs_table.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace fostercommerce\bestsellers\migrations;
+
+use craft\db\Migration;
+use fostercommerce\bestsellers\db\Table;
+
+class m260323_000001_create_backfill_logs_table extends Migration
+{
+	public function safeUp(): bool
+	{
+		if ($this->db->tableExists(Table::BACKFILL_LOGS)) {
+			return true;
+		}
+
+		$this->createTable(Table::BACKFILL_LOGS, [
+			'id' => $this->primaryKey(),
+			'level' => $this->string()->notNull()->defaultValue('error'),
+			'type' => $this->string()->notNull(),
+			'reference' => $this->string()->notNull(),
+			'message' => $this->text()->null(),
+			'dateCreated' => $this->dateTime()->notNull(),
+			'dateUpdated' => $this->dateTime()->notNull(),
+			'uid' => $this->uid(),
+		]);
+
+		$this->createIndex(null, Table::BACKFILL_LOGS, ['level']);
+		$this->createIndex(null, Table::BACKFILL_LOGS, ['type']);
+
+		return true;
+	}
+
+	public function safeDown(): bool
+	{
+		$this->dropTableIfExists(Table::BACKFILL_LOGS);
+		return true;
+	}
+}

--- a/src/migrations/m260323_000001_create_processing_failures_table.php
+++ b/src/migrations/m260323_000001_create_processing_failures_table.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace fostercommerce\bestsellers\migrations;
+
+use craft\db\Migration;
+use fostercommerce\bestsellers\db\Table;
+
+class m260323_000001_create_processing_failures_table extends Migration
+{
+	public function safeUp(): bool
+	{
+		if ($this->db->tableExists(Table::BACKFILL_LOGS)) {
+			return true;
+		}
+
+		$this->createTable(Table::BACKFILL_LOGS, [
+			'id' => $this->primaryKey(),
+			'level' => $this->string()->notNull()->defaultValue('error'),
+			'type' => $this->string()->notNull(),
+			'reference' => $this->string()->notNull(),
+			'message' => $this->text()->null(),
+			'dateCreated' => $this->dateTime()->notNull(),
+			'dateUpdated' => $this->dateTime()->notNull(),
+			'uid' => $this->uid(),
+		]);
+
+		$this->createIndex(null, Table::BACKFILL_LOGS, ['level']);
+		$this->createIndex(null, Table::BACKFILL_LOGS, ['type']);
+
+		return true;
+	}
+
+	public function safeDown(): bool
+	{
+		$this->dropTableIfExists(Table::BACKFILL_LOGS);
+		return true;
+	}
+}

--- a/src/records/BackfillLog.php
+++ b/src/records/BackfillLog.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace fostercommerce\bestsellers\records;
+
+use craft\db\ActiveRecord;
+use fostercommerce\bestsellers\db\Table;
+
+/**
+ * @property int $id
+ * @property string $level
+ * @property string $type
+ * @property string $reference
+ * @property string $message
+ * @property string $dateCreated
+ * @property string $dateUpdated
+ * @property string $uid
+ */
+class BackfillLog extends ActiveRecord
+{
+	public static function tableName(): string
+	{
+		return Table::BACKFILL_LOGS;
+	}
+}

--- a/src/services/BackfillLogs.php
+++ b/src/services/BackfillLogs.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace fostercommerce\bestsellers\services;
+
+use Craft;
+use craft\db\Query;
+use fostercommerce\bestsellers\db\Table;
+use fostercommerce\bestsellers\records\BackfillLog;
+use yii\base\Component;
+
+class BackfillLogs extends Component
+{
+	public const LOG_LIMIT = 500;
+
+	/**
+	 * @return list<array{id: int, level: string, type: string, reference: string, message: string, dateCreated: string}>
+	 */
+	public function getAll(?string $level = null): array
+	{
+		$query = $this->_createQuery()
+			->orderBy([
+				'dateCreated' => SORT_DESC,
+			])
+			->limit(self::LOG_LIMIT);
+
+		if ($level !== null) {
+			$query->andWhere([
+				'level' => $level,
+			]);
+		}
+
+		/** @var list<array{id: int, level: string, type: string, reference: string, message: string, dateCreated: string}> */
+		return $query->all();
+	}
+
+	public function log(string $type, string $reference, string $message, string $level = 'error'): void
+	{
+		$record = new BackfillLog();
+		$record->level = $level;
+		$record->type = $type;
+		$record->reference = $reference;
+		$record->message = $message;
+		$record->save(false);
+	}
+
+	public function deleteById(int $id): bool
+	{
+		$record = BackfillLog::findOne($id);
+		if ($record === null) {
+			return false;
+		}
+
+		return (bool) $record->delete();
+	}
+
+	public function deleteAll(): int
+	{
+		return BackfillLog::deleteAll();
+	}
+
+	public function hasLogs(): bool
+	{
+		return BackfillLog::find()->exists();
+	}
+
+	/**
+	 * Prune old log entries beyond the limit.
+	 */
+	public function prune(): void
+	{
+		$threshold = (new Query())
+			->select('dateCreated')
+			->from(Table::BACKFILL_LOGS)
+			->orderBy([
+				'dateCreated' => SORT_DESC,
+			])
+			->offset(self::LOG_LIMIT)
+			->limit(1)
+			->scalar();
+
+		if ($threshold === false) {
+			return;
+		}
+
+		Craft::$app->db->createCommand()
+			->delete(Table::BACKFILL_LOGS, ['<=', 'dateCreated', $threshold])
+			->execute();
+	}
+
+	/**
+	 * @return Query<array-key, mixed>
+	 */
+	private function _createQuery(): Query
+	{
+		return (new Query())
+			->select(['id', 'level', 'type', 'reference', 'message', 'dateCreated'])
+			->from(Table::BACKFILL_LOGS);
+	}
+}

--- a/src/templates/_operations.twig
+++ b/src/templates/_operations.twig
@@ -8,6 +8,68 @@
 
 {% set content %}
 	<div class="bs-reports-container">
+		{% if backfillLogs|length > 0 %}
+			<div class="bs-section">
+				<div style="display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 1rem;">
+					<h3 class="bs-section__title" style="margin: 0;">
+						{{ "Backfill Logs ({count})"|t('best-sellers', {count: backfillLogs|length}) }}
+					</h3>
+					<form method="POST" style="margin: 0;">
+						{{ actionInput('best-sellers/operations/clear-logs') }}
+						{{ csrfInput() }}
+						{{ redirectInput(cpUrl('best-sellers/operations')) }}
+						<button type="submit" class="btn small">{{ "Clear All"|t('best-sellers') }}</button>
+					</form>
+				</div>
+				<div class="bs-chart-container" style="border-color: #e74c3c;">
+					<table style="width: 100%; font-size: 0.9rem; border-collapse: collapse;">
+						<thead>
+							<tr>
+								<th style="text-align: left; padding: 0.5rem; border-bottom: 2px solid #e0e0e0; color: #6c757d; font-size: 0.8rem;">{{ "Level"|t('best-sellers') }}</th>
+								<th style="text-align: left; padding: 0.5rem; border-bottom: 2px solid #e0e0e0; color: #6c757d; font-size: 0.8rem;">{{ "Type"|t('best-sellers') }}</th>
+								<th style="text-align: left; padding: 0.5rem; border-bottom: 2px solid #e0e0e0; color: #6c757d; font-size: 0.8rem;">{{ "Reference"|t('best-sellers') }}</th>
+								<th style="text-align: left; padding: 0.5rem; border-bottom: 2px solid #e0e0e0; color: #6c757d; font-size: 0.8rem;">{{ "Message"|t('best-sellers') }}</th>
+								<th style="text-align: left; padding: 0.5rem; border-bottom: 2px solid #e0e0e0; color: #6c757d; font-size: 0.8rem;">{{ "Date"|t('best-sellers') }}</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for entry in backfillLogs %}
+								<tr>
+									<td style="padding: 0.5rem; white-space: nowrap;">
+										{% if entry.level == 'error' %}
+											<span style="color: #e74c3c;">{{ entry.level }}</span>
+										{% elseif entry.level == 'warning' %}
+											<span style="color: #f39c12;">{{ entry.level }}</span>
+										{% else %}
+											<span style="color: #6c757d;">{{ entry.level }}</span>
+										{% endif %}
+									</td>
+									<td style="padding: 0.5rem; white-space: nowrap;">
+										{% if entry.type == 'backfill' %}
+											{{ "Order Backfill"|t('best-sellers') }}
+										{% elseif entry.type == 'daily-stats' %}
+											{{ "Daily Stats"|t('best-sellers') }}
+										{% else %}
+											{{ entry.type }}
+										{% endif %}
+									</td>
+									<td style="padding: 0.5rem; white-space: nowrap;">
+										{% if entry.type == 'backfill' %}
+											<a href="{{ cpUrl('commerce/orders/' ~ entry.reference) }}">{{ 'Order #{id}'|t('best-sellers', {id: entry.reference}) }}</a>
+										{% else %}
+											{{ entry.reference }}
+										{% endif %}
+									</td>
+									<td style="padding: 0.5rem; font-size: 0.85rem;">{{ entry.message }}</td>
+									<td style="padding: 0.5rem; white-space: nowrap; color: #6c757d;">{{ entry.dateCreated }}</td>
+								</tr>
+							{% endfor %}
+						</tbody>
+					</table>
+				</div>
+			</div>
+		{% endif %}
+
 		{# Commerce Settings Links #}
 		<div class="bs-section">
 			<h3 class="bs-section__title">{{ "Commerce Settings"|t('best-sellers') }}</h3>

--- a/src/templates/_overview.twig
+++ b/src/templates/_overview.twig
@@ -8,13 +8,12 @@
 {% block reportContent %}
 	{% if not hasData %}
 		<div class="bs-empty-state">
-			<p>{{ "No order data has been recorded yet. If you have existing orders, run the backfill utility to import historical data."|t('best-sellers') }}</p>
+			<p>{{ "No order data has been processed yet. If you have existing orders, run the backfill utility to import historical data."|t('best-sellers') }}</p>
 			{% if currentUser.can('best-sellers:backfill') %}
 				<a href="{{ cpUrl('utilities/best-sellers') }}" class="btn submit">{{ "Go to Backfill Utility"|t('best-sellers') }}</a>
 			{% endif %}
 		</div>
-	{% endif %}
-
+	{% else %}
 	{# 1. Hero row #}
 	<div class="bs-section bs-section--hero">
 		{{ summaryBlock.render(summaries.orders) }}
@@ -91,8 +90,10 @@
 		{% include 'best-sellers/_includes/widgets/cart-abandonment' %}
 		{% include 'best-sellers/_includes/widgets/top-abandoned-carts' %}
 	</div>
+	{% endif %}
 {% endblock %}
 
+{% if hasData %}
 {% js %}
 document.addEventListener('DOMContentLoaded', function () {
 	var labels = {{ dailyLabels|json_encode|raw }};
@@ -456,3 +457,4 @@ document.addEventListener('DOMContentLoaded', function () {
 	}
 });
 {% endjs %}
+{% endif %}

--- a/src/templates/_overview.twig
+++ b/src/templates/_overview.twig
@@ -6,6 +6,15 @@
 {% set selectedSubnavItem = 'overview' %}
 
 {% block reportContent %}
+	{% if not hasData %}
+		<div class="bs-empty-state">
+			<p>{{ "No order data has been recorded yet. If you have existing orders, run the backfill utility to import historical data."|t('best-sellers') }}</p>
+			{% if currentUser.can('best-sellers:backfill') %}
+				<a href="{{ cpUrl('utilities/best-sellers') }}" class="btn submit">{{ "Go to Backfill Utility"|t('best-sellers') }}</a>
+			{% endif %}
+		</div>
+	{% endif %}
+
 	{# 1. Hero row #}
 	<div class="bs-section bs-section--hero">
 		{{ summaryBlock.render(summaries.orders) }}

--- a/src/templates/_utilities/backfill.twig
+++ b/src/templates/_utilities/backfill.twig
@@ -1,31 +1,28 @@
 {% import '_includes/forms' as forms %}
 
-<h2>Backfill Orders</h2>
-<p>
-	Use the fields below to limit which orders get backfilled.
-</p>
+<h2>{{ "Backfill Orders"|t('best-sellers') }}</h2>
+<p>{{ "Import completed orders that were placed before the plugin was installed. Only orders not already recorded will be processed."|t('best-sellers') }}</p>
+<p class="light">{{ "Leave both dates empty to backfill all completed orders. Set a date range to limit which orders are imported."|t('best-sellers') }}</p>
 <form method="POST">
 	{{ actionInput('best-sellers/backfill') }}
 	{{ csrfInput() }}
 	<div class="field">
-		<label for="startDate">Start Date</label>
+		<label for="startDate">{{ "Start Date"|t('best-sellers') }}</label>
 		<input type="date" name="startDate" id="startDate">
 	</div>
 	<div class="field">
-		<label for="endDate">End Date</label>
+		<label for="endDate">{{ "End Date"|t('best-sellers') }}</label>
 		<input type="date" name="endDate" id="endDate">
 	</div>
-	<button type="submit" class="btn submit">Start Backfill</button>
+	<button type="submit" class="btn submit">{{ "Start Backfill"|t('best-sellers') }}</button>
 </form>
 
 <hr style="margin: 2rem 0;">
 
-<h2>Rebuild Daily Stats</h2>
-<p>
-	Rebuild the pre-aggregated daily statistics table from commerce order data. This is useful after a backfill or if stats appear out of sync.
-</p>
+<h2>{{ "Rebuild Daily Stats"|t('best-sellers') }}</h2>
+<p>{{ "Rebuild the pre-aggregated daily statistics table from commerce order data. This is useful after a backfill or if stats appear out of sync."|t('best-sellers') }}</p>
 <form method="POST">
 	{{ actionInput('best-sellers/backfill/rebuild-daily-stats') }}
 	{{ csrfInput() }}
-	<button type="submit" class="btn submit">Rebuild Daily Stats</button>
+	<button type="submit" class="btn submit">{{ "Rebuild Daily Stats"|t('best-sellers') }}</button>
 </form>

--- a/src/templates/_utilities/backfill.twig
+++ b/src/templates/_utilities/backfill.twig
@@ -6,23 +6,49 @@
 <form method="POST">
 	{{ actionInput('best-sellers/backfill') }}
 	{{ csrfInput() }}
-	<div class="field">
-		<label for="startDate">{{ "Start Date"|t('best-sellers') }}</label>
-		<input type="date" name="startDate" id="startDate">
-	</div>
-	<div class="field">
-		<label for="endDate">{{ "End Date"|t('best-sellers') }}</label>
-		<input type="date" name="endDate" id="endDate">
-	</div>
+	{{ forms.dateField({
+		label: "Start Date"|t('best-sellers'),
+		id: 'startDate',
+		name: 'startDate',
+	}) }}
+	{{ forms.dateField({
+		label: "End Date"|t('best-sellers'),
+		id: 'endDate',
+		name: 'endDate',
+	}) }}
 	<button type="submit" class="btn submit">{{ "Start Backfill"|t('best-sellers') }}</button>
 </form>
+<div style="display: flex; gap: 0.75rem; margin-top: 1rem;">
+	<form method="POST" style="margin: 0;">
+		{{ actionInput('best-sellers/backfill/refresh-orders') }}
+		{{ csrfInput() }}
+		<button type="submit" class="btn">{{ "Clear and Reprocess"|t('best-sellers') }}</button>
+	</form>
+	<form method="POST" style="margin: 0;">
+		{{ actionInput('best-sellers/backfill/clear-orders') }}
+		{{ csrfInput() }}
+		<button type="submit" class="btn">{{ "Clear Order Data"|t('best-sellers') }}</button>
+	</form>
+</div>
 
 <hr style="margin: 2rem 0;">
 
 <h2>{{ "Rebuild Daily Stats"|t('best-sellers') }}</h2>
 <p>{{ "Rebuild the pre-aggregated daily statistics table from commerce order data. This is useful after a backfill or if stats appear out of sync."|t('best-sellers') }}</p>
-<form method="POST">
+<form method="POST" style="margin: 0;">
 	{{ actionInput('best-sellers/backfill/rebuild-daily-stats') }}
 	{{ csrfInput() }}
 	<button type="submit" class="btn submit">{{ "Rebuild Daily Stats"|t('best-sellers') }}</button>
 </form>
+<div style="display: flex; gap: 0.75rem; margin-top: 1rem;">
+	<form method="POST" style="margin: 0;">
+		{{ actionInput('best-sellers/backfill/refresh-daily-stats') }}
+		{{ csrfInput() }}
+		<button type="submit" class="btn">{{ "Clear and Rebuild"|t('best-sellers') }}</button>
+	</form>
+	<form method="POST" style="margin: 0;">
+		{{ actionInput('best-sellers/backfill/clear-daily-stats') }}
+		{{ csrfInput() }}
+		<button type="submit" class="btn">{{ "Clear Daily Stats"|t('best-sellers') }}</button>
+	</form>
+</div>


### PR DESCRIPTION
### Added
- Backfill logs table for tracking order processing failures during backfill and daily stats jobs
- Backfill logs displayed on the Operations page with clear button
- Dashboard empty state notice with link to backfill utility when no data exists
- Console commands for clearing and refreshing individual data tables: `clear-orders`, `clear-daily-stats`, `clear-logs`, `refresh-orders`, `refresh-daily-stats`
- Console `--start-date`/`--end-date` options for scoping backfill to a date range
- Console `--date` option for rebuilding daily stats for a single day
- Auto-pruning of backfill logs via Craft garbage collection (keeps 500 most recent)

### Changed
- Backfill utility UI now explains that empty date fields will process all orders
- All backfill utility strings are translatable
- Backfill and daily stats jobs now catch errors per-item and continue processing instead of failing the entire batch